### PR TITLE
Adds support for Php 7 random_bytes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
 	"support" : {
 		"source" : "https://github.com/webpatser/uuid",
 		"issues" : "https://github.com/webpatser/uuid/issues"
+	},
+	"suggest" : {
+		"paragonie/random_compat": "A random_bytes Php 5.x polyfill."
 	}
 }

--- a/src/Webpatser/Uuid/Uuid.php
+++ b/src/Webpatser/Uuid/Uuid.php
@@ -368,7 +368,7 @@ class Uuid
     }
     
     /**
-     * Ge the specified number of random bytes, using random_bytes().
+     * Get the specified number of random bytes, using random_bytes().
      * Randomness is returned as a string of bytes
      * 
      * Requires Php 7, or random_compact polyfill

--- a/src/Webpatser/Uuid/Uuid.php
+++ b/src/Webpatser/Uuid/Uuid.php
@@ -224,7 +224,8 @@ class Uuid
     }
 
     /**
-     * Trying for openSSL and Mcrypt random generators. Fallback to mt_rand
+     * Trying for php 7 secure random generator, falling back to openSSL and Mcrypt.
+     * If none of the above is foumd, falls back to mt_rand
      * Since laravel 4.* and 5.0 requires Mcrypt and 5.1 requires OpenSSL the fallback should never be used.
      *
      * @throws Exception
@@ -232,7 +233,9 @@ class Uuid
      */
     public static function initRandom()
     {
-        if (function_exists('openssl_random_pseudo_bytes')) {
+        if (function_exists('random_bytes')) {
+            return 'randomPhp7';
+        } elseif (function_exists('openssl_random_pseudo_bytes')) {
             return 'randomOpenSSL';
         } elseif (function_exists('mcrypt_encrypt')) {
             return 'randomMcrypt';
@@ -362,6 +365,19 @@ class Uuid
         } else {
             return false;
         }
+    }
+    
+    /**
+     * Ge the specified number of random bytes, using random_bytes().
+     * Randomness is returned as a string of bytes
+     * 
+     * Requires Php 7, or random_compact polyfill
+     * 
+     * @param $bytes
+     * @return mixed
+     */
+    protected static function randomPhp7($bytes) {
+        return random_bytes($bytes);
     }
 
     /**

--- a/src/Webpatser/Uuid/Uuid.php
+++ b/src/Webpatser/Uuid/Uuid.php
@@ -225,7 +225,7 @@ class Uuid
 
     /**
      * Trying for php 7 secure random generator, falling back to openSSL and Mcrypt.
-     * If none of the above is foumd, falls back to mt_rand
+     * If none of the above is found, falls back to mt_rand
      * Since laravel 4.* and 5.0 requires Mcrypt and 5.1 requires OpenSSL the fallback should never be used.
      *
      * @throws Exception


### PR DESCRIPTION
and as a side effect, random_compact polyfill.

Php 7's random_bytes function is place first. Reasoning: As explained in the following blog article, OpenSSL may not provide truly secure random bytes, https://paragonie.com/blog/2015/07/how-safely-generate-random-strings-and-integers-in-php 

random_compact attempts to use mcrypt as apart of it's polyfill.