### PR TITLE
Added Lumen compatibility

### DIFF
--- a/src/Webpatser/Uuid/UuidServiceProvider.php
+++ b/src/Webpatser/Uuid/UuidServiceProvider.php
@@ -14,7 +14,7 @@ class UuidServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Validator::extend('uuid', function ($attribute, $value, $parameters, $validator) {
+        app('validator')->extend('uuid', function ($attribute, $value, $parameters, $validator) {
             return Uuid::validate($value);
         });
     }


### PR DESCRIPTION
It's not required for Lumen to use facade and the `app('validator')` does the same. So, after approving the PR the lumen users will also be able to use the package.