### PR TITLE
Fix deprecation notices in PHP 8.2 

### DIFF
--- a/src/Webpatser/Uuid/Uuid.php
+++ b/src/Webpatser/Uuid/Uuid.php
@@ -113,7 +113,11 @@ class Uuid
      * Regular expression for validation of UUID.
      */
     const VALID_UUID_REGEX = '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$';
-    
+
+    protected string $bytes;
+    protected string $string;
+    protected string $uuid_ordered;
+
     /**
      * @param string $uuid
      * @throws Exception

--- a/src/Webpatser/Uuid/Uuid.php
+++ b/src/Webpatser/Uuid/Uuid.php
@@ -114,9 +114,9 @@ class Uuid
      */
     const VALID_UUID_REGEX = '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$';
 
-    protected string $bytes;
-    protected string $string;
-    protected string $uuid_ordered;
+    protected $bytes;
+    protected $string;
+    protected $uuid_ordered;
 
     /**
      * @param string $uuid


### PR DESCRIPTION
PHP 8.2 add a new deprecation of dynamic properties.
I have added a properties that was assigned dynamically within the class.